### PR TITLE
No longer exposing Expand-Zip and Test-Zip

### DIFF
--- a/Scripts/CommunityBuilder/CommunityBuilder.psd1
+++ b/Scripts/CommunityBuilder/CommunityBuilder.psd1
@@ -90,9 +90,6 @@ FunctionsToExport = @(
                     'Install-CommunityHotfix'
                     'Install-CommunityLicence'
 
-                    'Test-Zip'
-                    'Expand-Zip'
-
                     'New-IISAppPool'
                     'Get-IISAppPoolIdentity'
                     'New-CommunityWebsite'

--- a/Scripts/CommunityBuilder/zip.ps1
+++ b/Scripts/CommunityBuilder/zip.ps1
@@ -3,7 +3,7 @@
 function Expand-Zip {
 	<#
 	.Synopsis
-		Extracts files from a zip folder
+		Extracts files or directories from a zip folder
 	.Parameter Path
 	    The path to the Zip folder to extract
 	.Parameter Destination


### PR DESCRIPTION
These are internal functions.  Can't replace Expand-Zip with WMF5's Expand-Archive as it doesn't have support for extracting just part of a zip file. Fixes #7
