### PR TITLE
Avoiding ambiguity between two install functions

### DIFF
--- a/TelligentInstall/Install.ps1
+++ b/TelligentInstall/Install.ps1
@@ -1,11 +1,11 @@
 ﻿Set-StrictMode -Version 2
 
-function Install-Community {
+function Install-TelligentCommunity {
 	<#
 	.Synopsis
 		Sets up a new Telligent Community.
 	.Description
-		The Install-Community cmdlet automates the process of creating a new Telligent Community.
+		The Install-TelligentCommunity cmdlet automates the process of creating a new Telligent Evolution community.
 		
 		It takes the installation package, and from it deploys the website to IIS and a creates a new database using
 		the scripts from the package. It also sets permissions automatically.
@@ -51,7 +51,7 @@ function Install-Community {
 	.Parameter License
 	    The path to the License XML file to install in the community
 	.Example
-		Install-Community -name 'Telligent Community' -package d:\temp\TelligentCommunity-7.0.1824.27400.zip -webDir "d:\inetpub\TelligentCommunity\" -webdomain "mydomain.com" -searchUrl "http://localhost:8080/solr/"
+		Install-TelligentCommunity -name 'Telligent Evolution' -package d:\temp\TelligentCommunity-7.0.1824.27400.zip -webDir "d:\inetpub\TelligentEvolution\" -webdomain "mydomain.com" -searchUrl "http://localhost:8080/solr/"
 		
 		Description
 		-----------
@@ -293,7 +293,7 @@ function Install-TelligentHotfix {
     Remove-Item $tempDir -Recurse -Force | Out-Null
 }
 
-function Uninstall-Community {
+function Uninstall-TelligentCommunity {
     <#
     .SYNOPSIS
         Uninstalls a Telligent Community  
@@ -302,7 +302,6 @@ function Uninstall-Community {
     .PARAMETER JobSchedulerPath
         The path to the Telligent Community Job Scheduler.
     #>
-
 	[CmdletBinding(DefaultParameterSetName='NoService')]
     param(
     	[Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true)]

--- a/TelligentInstall/TelligentInstall.psd1
+++ b/TelligentInstall/TelligentInstall.psd1
@@ -85,8 +85,6 @@ FunctionsToExport = @(
                     'Set-TelligentSolrUrl'
                     'Remove-SolrCore'
 
-                    'Install-Community'
-                    'Uninstall-Community'
                     'Install-TelligentLicense'
 
                     'New-IISAppPool'

--- a/TelligentLocalInstance/TelligentLocalInstance.ps1
+++ b/TelligentLocalInstance/TelligentLocalInstance.ps1
@@ -166,7 +166,14 @@ function Install-TelligentInstance {
 	$licensePath = join-path $data.LicensesPath "Community$($Version.Major).xml"
 	if(!(Test-Path $licensePath)) { $licensePath = $null }
 
-    $info = Install-Community -name $Name `
+
+	# To avoid ambiguity between the enviornment specificl Install-TelligentCommunity and
+	# the generic base, the base function is private, so have to pull it out via a bit
+	# of module hackery
+	$module = Get-Module TelligentInstall
+	$installCommunityFunc = $module.Invoke({Get-Command Install-TelligentCommunity})
+    $info = & $installCommunityFunc `
+		-Name $Name `
         -Package $BasePackage `
         -Hotfix $HotfixPackage `
         -WebsitePath $webDir `


### PR DESCRIPTION
Currently there are two functions to install a community - `Install-TelligentCommunity` and `Install-TelligentInstance`.  The latter is specific to the TelligentLocalInstance module, which wraps the former with conventions for a local installation.  However to someone just using help to find the function, the desperation between these two is unclear.

For now I made the base function internal and use some hackery to invoke it from the `Install-TelligentInstance` function.  I'm not keen on this, but can't come up with a better idea right now.

Fixes #21
